### PR TITLE
Separate detection of shell and binary format

### DIFF
--- a/src/Charmonizer/Core/Compiler.c
+++ b/src/Charmonizer/Core/Compiler.c
@@ -27,6 +27,16 @@
 static void
 chaz_CC_detect_binary_format(const char *filename);
 
+/** Return the numeric value of a macro or 0 if it isn't defined.
+ */
+static int
+chaz_CC_eval_macro(const char *macro);
+
+/** Return true if macro is defined.
+ */
+static int
+chaz_CC_has_macro(const char *macro);
+
 /* Detect macros which may help to identify some compilers.
  */
 static void
@@ -56,12 +66,13 @@ static struct {
     int       intval__MSC_VER;
     int       intval___clang__;
     int       intval___SUNPRO_C;
+    int       is_cygwin;
     chaz_CFlags *extra_cflags;
     chaz_CFlags *temp_cflags;
 } chaz_CC = {
     NULL, NULL, NULL,
     "", "", "", "", "", "",
-    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0,
     NULL, NULL
 };
 
@@ -167,6 +178,10 @@ chaz_CC_init(const char *compiler_command, const char *compiler_flags) {
             strcpy(chaz_CC.import_lib_ext, ".lib");
             strcpy(chaz_CC.obj_ext, ".obj");
         }
+
+        if (chaz_CC_has_macro("__CYGWIN__")) {
+            chaz_CC.is_cygwin = 1;
+        }
     }
     else {
         chaz_Util_die("Failed to detect binary format");
@@ -224,7 +239,7 @@ chaz_CC_detect_binary_format(const char *filename) {
     free(output);
 }
 
-static const char chaz_CC_detect_macro_code[] =
+static const char chaz_CC_eval_macro_code[] =
     CHAZ_QUOTE(  #include <stdio.h>             )
     CHAZ_QUOTE(  int main() {                   )
     CHAZ_QUOTE(  #ifndef %s                     )
@@ -235,15 +250,15 @@ static const char chaz_CC_detect_macro_code[] =
     CHAZ_QUOTE(  }                              );
 
 static int
-chaz_CC_detect_macro(const char *macro) {
-    size_t size = sizeof(chaz_CC_detect_macro_code)
+chaz_CC_eval_macro(const char *macro) {
+    size_t size = sizeof(chaz_CC_eval_macro_code)
                   + (strlen(macro) * 2)
                   + 20;
     char *code = (char*)malloc(size);
     int retval = 0;
     char *output;
     size_t len;
-    sprintf(code, chaz_CC_detect_macro_code, macro, macro);
+    sprintf(code, chaz_CC_eval_macro_code, macro, macro);
     output = chaz_CC_capture_output(code, &len);
     if (output) {
         retval = atoi(output);
@@ -253,21 +268,34 @@ chaz_CC_detect_macro(const char *macro) {
     return retval;
 }
 
+static int
+chaz_CC_has_macro(const char *macro) {
+    size_t size = sizeof(chaz_CC_eval_macro_code)
+                  + (strlen(macro) * 2)
+                  + 20;
+    char *code = (char*)malloc(size);
+    int retval = 0;
+    sprintf(code, chaz_CC_eval_macro_code, macro, macro);
+    retval = chaz_CC_test_compile(code);
+    free(code);
+    return retval;
+}
+
 static void
 chaz_CC_detect_known_compilers(void) {
-    chaz_CC.intval___GNUC__  = chaz_CC_detect_macro("__GNUC__");
+    chaz_CC.intval___GNUC__  = chaz_CC_eval_macro("__GNUC__");
     if (chaz_CC.intval___GNUC__) {
         chaz_CC.intval___GNUC_MINOR__
-            = chaz_CC_detect_macro("__GNUC_MINOR__");
+            = chaz_CC_eval_macro("__GNUC_MINOR__");
         chaz_CC.intval___GNUC_PATCHLEVEL__
-            = chaz_CC_detect_macro("__GNUC_PATCHLEVEL__");
+            = chaz_CC_eval_macro("__GNUC_PATCHLEVEL__");
         sprintf(chaz_CC.gcc_version_str, "%d.%d.%d", chaz_CC.intval___GNUC__,
                 chaz_CC.intval___GNUC_MINOR__,
                 chaz_CC.intval___GNUC_PATCHLEVEL__);
     }
-    chaz_CC.intval__MSC_VER   = chaz_CC_detect_macro("_MSC_VER");
-    chaz_CC.intval___clang__  = chaz_CC_detect_macro("__clang__");
-    chaz_CC.intval___SUNPRO_C = chaz_CC_detect_macro("__SUNPRO_C");
+    chaz_CC.intval__MSC_VER   = chaz_CC_eval_macro("_MSC_VER");
+    chaz_CC.intval___clang__  = chaz_CC_eval_macro("__clang__");
+    chaz_CC.intval___SUNPRO_C = chaz_CC_eval_macro("__SUNPRO_C");
 }
 
 void
@@ -520,6 +548,11 @@ chaz_CC_msvc_version_num(void) {
 int
 chaz_CC_sun_c_version_num(void) {
     return chaz_CC.intval___SUNPRO_C;
+}
+
+int
+chaz_CC_is_cygwin(void) {
+    return chaz_CC.is_cygwin;
 }
 
 const char*

--- a/src/Charmonizer/Core/Compiler.c
+++ b/src/Charmonizer/Core/Compiler.c
@@ -32,11 +32,6 @@ chaz_CC_detect_binary_format(const char *filename);
 static int
 chaz_CC_eval_macro(const char *macro);
 
-/** Return true if macro is defined.
- */
-static int
-chaz_CC_has_macro(const char *macro);
-
 /* Detect macros which may help to identify some compilers.
  */
 static void
@@ -268,7 +263,7 @@ chaz_CC_eval_macro(const char *macro) {
     return retval;
 }
 
-static int
+int
 chaz_CC_has_macro(const char *macro) {
     size_t size = sizeof(chaz_CC_eval_macro_code)
                   + (strlen(macro) * 2)

--- a/src/Charmonizer/Core/Compiler.h
+++ b/src/Charmonizer/Core/Compiler.h
@@ -66,6 +66,11 @@ chaz_CC_test_link(const char *source);
 char*
 chaz_CC_capture_output(const char *source, size_t *output_len);
 
+/** Return true if macro is defined.
+ */
+int
+chaz_CC_has_macro(const char *macro);
+
 /** Initialize the compiler environment.
  */
 void

--- a/src/Charmonizer/Core/Compiler.h
+++ b/src/Charmonizer/Core/Compiler.h
@@ -28,6 +28,10 @@ extern "C" {
 #include "Charmonizer/Core/Defines.h"
 #include "Charmonizer/Core/CFlags.h"
 
+#define CHAZ_CC_BINFMT_ELF      1
+#define CHAZ_CC_BINFMT_MACHO    2
+#define CHAZ_CC_BINFMT_PE       3
+
 /* Attempt to compile and link an executable.  Return true if the executable
  * file exists after the attempt.
  */
@@ -96,6 +100,31 @@ chaz_CC_get_temp_cflags(void);
  */
 chaz_CFlags*
 chaz_CC_new_cflags(void);
+
+/* Return the binary format.
+ */
+int
+chaz_CC_binary_format(void);
+
+/* Return the extension for an executable.
+ */
+const char*
+chaz_CC_exe_ext(void);
+
+/* Return the extension for a shared (dynamic) library.
+ */
+const char*
+chaz_CC_shared_lib_ext(void);
+
+/* Return the extension for a static library.
+ */
+const char*
+chaz_CC_static_lib_ext(void);
+
+/* Return the extension for an import library (Windows).
+ */
+const char*
+chaz_CC_import_lib_ext(void);
 
 /* Return the extension for a compiled object.
  */

--- a/src/Charmonizer/Core/Compiler.h
+++ b/src/Charmonizer/Core/Compiler.h
@@ -143,6 +143,9 @@ chaz_CC_msvc_version_num(void);
 int
 chaz_CC_sun_c_version_num(void);
 
+int
+chaz_CC_is_cygwin(void);
+
 const char*
 chaz_CC_link_command(void);
 

--- a/src/Charmonizer/Core/Library.c
+++ b/src/Charmonizer/Core/Library.c
@@ -33,7 +33,7 @@ static char*
 S_build_filename(chaz_Lib *lib, const char *version, const char *ext);
 
 static const char*
-S_get_prefix(void);
+S_get_prefix(chaz_Lib *lib);
 
 chaz_Lib*
 chaz_Lib_new_shared(const char *name, const char *version,
@@ -120,7 +120,7 @@ chaz_Lib_major_version_filename(chaz_Lib *lib) {
 
 char*
 chaz_Lib_no_version_filename(chaz_Lib *lib) {
-    const char *prefix = S_get_prefix();
+    const char *prefix = S_get_prefix(lib);
     const char *ext = lib->is_shared
                       ? chaz_CC_shared_lib_ext()
                       : chaz_CC_static_lib_ext();
@@ -140,7 +140,7 @@ chaz_Lib_export_filename(chaz_Lib *lib) {
 
 static char*
 S_build_filename(chaz_Lib *lib, const char *version, const char *ext) {
-    const char *prefix = S_get_prefix();
+    const char *prefix = S_get_prefix(lib);
     int binary_format = chaz_CC_binary_format();
 
     if (binary_format == CHAZ_CC_BINFMT_PE) {
@@ -159,14 +159,13 @@ S_build_filename(chaz_Lib *lib, const char *version, const char *ext) {
 }
 
 static const char*
-S_get_prefix() {
+S_get_prefix(chaz_Lib *lib) {
     if (chaz_CC_msvc_version_num()) {
         return "";
     }
-    /* TODO: Readd Cygwin detection. */
-    /*else if (chaz_OS_is_cygwin()) {
-        return "cyg";
-    }*/
+    else if (chaz_CC_is_cygwin()) {
+        return lib->is_static ? "lib" : "cyg";
+    }
     else {
         return "lib";
     }

--- a/src/Charmonizer/Core/Library.c
+++ b/src/Charmonizer/Core/Library.c
@@ -97,8 +97,8 @@ chaz_Lib_filename(chaz_Lib *lib) {
         return chaz_Lib_no_version_filename(lib);
     }
     else {
-        const char *ext = chaz_OS_shared_lib_ext();
-        if (strcmp(ext, ".dll") == 0) {
+        const char *ext = chaz_CC_shared_lib_ext();
+        if (chaz_CC_binary_format() == CHAZ_CC_BINFMT_PE) {
             return S_build_filename(lib, lib->major_version, ext);
         }
         else {
@@ -113,7 +113,7 @@ chaz_Lib_major_version_filename(chaz_Lib *lib) {
         return chaz_Lib_no_version_filename(lib);
     }
     else {
-        const char *ext = chaz_OS_shared_lib_ext();
+        const char *ext = chaz_CC_shared_lib_ext();
         return S_build_filename(lib, lib->major_version, ext);
     }
 }
@@ -122,14 +122,15 @@ char*
 chaz_Lib_no_version_filename(chaz_Lib *lib) {
     const char *prefix = S_get_prefix();
     const char *ext = lib->is_shared
-                      ? chaz_OS_shared_lib_ext()
-                      : chaz_OS_static_lib_ext();
+                      ? chaz_CC_shared_lib_ext()
+                      : chaz_CC_static_lib_ext();
     return chaz_Util_join("", prefix, lib->name, ext, NULL);
 }
 
 char*
 chaz_Lib_implib_filename(chaz_Lib *lib) {
-    return S_build_filename(lib, lib->major_version, ".lib");
+    const char *ext = chaz_CC_import_lib_ext();
+    return S_build_filename(lib, lib->major_version, ext);
 }
 
 char*
@@ -139,19 +140,21 @@ chaz_Lib_export_filename(chaz_Lib *lib) {
 
 static char*
 S_build_filename(chaz_Lib *lib, const char *version, const char *ext) {
-    const char *prefix    = S_get_prefix();
-    const char *shlib_ext = chaz_OS_shared_lib_ext();
+    const char *prefix = S_get_prefix();
+    int binary_format = chaz_CC_binary_format();
 
-    /* Use `shlib_ext` as a proxy for OS to determine behavior, but append
-     * the supplied `ext`. */
-    if (strcmp(shlib_ext, ".dll") == 0) {
+    if (binary_format == CHAZ_CC_BINFMT_PE) {
         return chaz_Util_join("", prefix, lib->name, "-", version, ext, NULL);
     }
-    else if (strcmp(shlib_ext, ".dylib") == 0) {
+    else if (binary_format == CHAZ_CC_BINFMT_MACHO) {
         return chaz_Util_join("", prefix, lib->name, ".", version, ext, NULL);
     }
-    else {
+    else if (binary_format == CHAZ_CC_BINFMT_ELF) {
         return chaz_Util_join("", prefix, lib->name, ext, ".", version, NULL);
+    }
+    else {
+        chaz_Util_die("Unsupported binary format");
+        return NULL;
     }
 }
 
@@ -160,9 +163,10 @@ S_get_prefix() {
     if (chaz_CC_msvc_version_num()) {
         return "";
     }
-    else if (chaz_OS_is_cygwin()) {
+    /* TODO: Readd Cygwin detection. */
+    /*else if (chaz_OS_is_cygwin()) {
         return "cyg";
-    }
+    }*/
     else {
         return "lib";
     }

--- a/src/Charmonizer/Core/Make.c
+++ b/src/Charmonizer/Core/Make.c
@@ -688,15 +688,27 @@ chaz_MakeRule_add_command_with_libpath(chaz_MakeRule *rule,
         free(path);
     }
     else if (binfmt == CHAZ_CC_BINFMT_PE) {
-        va_start(args, command);
-        path = chaz_Util_vjoin(";", args);
-        va_end(args);
+        if (chaz_Make.shell_type == CHAZ_OS_CMD_EXE) {
+            va_start(args, command);
+            path = chaz_Util_vjoin(";", args);
+            va_end(args);
 
-        /* It's important to not add a space before `&&`. Otherwise, the
-	 * space is added to the search path.
-	 */
-        lib_command = chaz_Util_join("", "path ", path, ";%path%&& ", command,
-                                     NULL);
+            /* It's important to not add a space before `&&`. Otherwise, the
+             * space is added to the search path.
+             */
+            lib_command = chaz_Util_join("", "path ", path, ";%path%&& ",
+                                         command, NULL);
+        }
+        else {
+            va_start(args, command);
+            path = chaz_Util_vjoin(":", args);
+            va_end(args);
+
+            lib_command = chaz_Util_join("", "PATH=", path, ":$$PATH ",
+                                         command, NULL);
+        }
+
+        free(path);
     }
     else {
         /* Assume that library paths are compiled into the executable on

--- a/src/Charmonizer/Core/Make.c
+++ b/src/Charmonizer/Core/Make.c
@@ -80,6 +80,8 @@ S_write_rule(chaz_MakeRule *rule, FILE *out);
 
 void
 chaz_Make_init(const char *make_command) {
+    chaz_Make.shell_type = chaz_OS_shell_type();
+
     if (make_command) {
         if (!chaz_Make_detect(make_command, NULL)) {
             chaz_Util_warn("Make utility '%s' doesn't appear to work");
@@ -94,11 +96,6 @@ chaz_Make_init(const char *make_command) {
         else if (chaz_Util_verbosity) {
             printf("Detected make utility '%s'\n", chaz_Make.make_command);
         }
-    }
-
-    if (chaz_Make.shell_type == 0) {
-        // Assume POSIX.
-        chaz_Make.shell_type = CHAZ_OS_POSIX;
     }
 }
 
@@ -149,12 +146,14 @@ chaz_Make_audition(const char *make) {
         size_t len;
         char *content = chaz_Util_slurp_file("_charm_foo", &len);
         if (NULL != strstr(content, "foo\\bar")) {
-            chaz_Make.shell_type = CHAZ_OS_CMD_EXE;
-            succeeded = 1;
+            if (chaz_Make.shell_type == CHAZ_OS_CMD_EXE) {
+                succeeded = 1;
+            }
         }
         else if (NULL != strstr(content, "foo^bar")) {
-            chaz_Make.shell_type = CHAZ_OS_POSIX;
-            succeeded = 1;
+            if (chaz_Make.shell_type == CHAZ_OS_POSIX) {
+                succeeded = 1;
+            }
         }
         free(content);
     }

--- a/src/Charmonizer/Core/OperatingSystem.c
+++ b/src/Charmonizer/Core/OperatingSystem.c
@@ -33,107 +33,52 @@ static struct {
     char name[CHAZ_OS_NAME_MAX+1];
     char dev_null[20];
     char dir_sep[2];
-    char exe_ext[5];
-    char static_lib_ext[5];
-    char shared_lib_ext[7];
     char local_command_start[3];
     int  shell_type;
-} chaz_OS = { "", "", "", "", "", "", "", 0 };
+} chaz_OS = { "", "", "", "", 0 };
 
 void
 chaz_OS_init(void) {
+    char *output;
+    size_t output_len;
+
     if (chaz_Util_verbosity) {
         printf("Initializing Charmonizer/Core/OperatingSystem...\n");
     }
 
-    if (chaz_Util_verbosity) {
-        printf("Trying to find a bit-bucket a la /dev/null...\n");
-    }
+    /* Detect shell based on escape character. */
 
-    /* Detect shell based on whether the bitbucket is "/dev/null" or "nul".
-     * Start with "nul" as some Windows boxes seem to have a "/dev/null".
-     */
-    if (chaz_Util_can_open_file("nul")) {
-        strcpy(chaz_OS.name, "windows");
-        strcpy(chaz_OS.dev_null, "nul");
-        strcpy(chaz_OS.dir_sep, "\\");
-        strcpy(chaz_OS.exe_ext, ".exe");
-        strcpy(chaz_OS.shared_lib_ext, ".dll");
-        strcpy(chaz_OS.static_lib_ext, ".lib");
-        strcpy(chaz_OS.local_command_start, ".\\");
+    /* Needed to make redirection work. */
+    chaz_OS.shell_type = CHAZ_OS_POSIX;
+
+    output = chaz_OS_run_and_capture("echo foo\\^bar", &output_len);
+
+    if (strncmp(output, "foo\\bar", 7) == 0) {
+        /* Escape character is caret. */
+        if (chaz_Util_verbosity) {
+            printf("Detected cmd.exe shell\n");
+        }
         chaz_OS.shell_type = CHAZ_OS_CMD_EXE;
+        strcpy(chaz_OS.dir_sep, "\\");
+        strcpy(chaz_OS.dev_null, "nul");
+        /* Empty string should work, too. */
+        strcpy(chaz_OS.local_command_start, ".\\");
     }
-    else if (chaz_Util_can_open_file("/dev/null")) {
-        char   *uname;
-        size_t  uname_len;
-        size_t i;
-
+    else if (strncmp(output, "foo^bar", 7) == 0) {
+        /* Escape character is backslash. */
+        if (chaz_Util_verbosity) {
+            printf("Detected POSIX shell\n");
+        }
         chaz_OS.shell_type = CHAZ_OS_POSIX;
-
-        /* Detect Unix name. */
-        uname = chaz_OS_run_and_capture("uname", &uname_len);
-        for (i = 0; i < CHAZ_OS_NAME_MAX && i < uname_len; i++) {
-            char c = uname[i];
-            if (!c || isspace((unsigned char)c)) { break; }
-            chaz_OS.name[i] = tolower((unsigned char)c);
-        }
-        if (i > 0) { chaz_OS.name[i] = '\0'; }
-        else       { strcpy(chaz_OS.name, "unknown_unix"); }
-        free(uname);
-
-        strcpy(chaz_OS.dev_null, "/dev/null");
         strcpy(chaz_OS.dir_sep, "/");
-        strcpy(chaz_OS.exe_ext, "");
-        strcpy(chaz_OS.static_lib_ext, ".a");
-        if (memcmp(chaz_OS.name, "darwin", 6) == 0) {
-            strcpy(chaz_OS.shared_lib_ext, ".dylib");
-        }
-        else if (memcmp(chaz_OS.name, "cygwin", 6) == 0) {
-            strcpy(chaz_OS.shared_lib_ext, ".dll");
-        }
-        else {
-            strcpy(chaz_OS.shared_lib_ext, ".so");
-        }
+        strcpy(chaz_OS.dev_null, "/dev/null");
         strcpy(chaz_OS.local_command_start, "./");
     }
     else {
-        /* Bail out because we couldn't find anything like /dev/null. */
-        chaz_Util_die("Couldn't find anything like /dev/null");
+        chaz_Util_die("Couldn't identify shell");
     }
 
-    if (chaz_Util_verbosity) {
-        printf("Detected OS: %s\n", chaz_OS.name);
-    }
-}
-
-const char*
-chaz_OS_name(void) {
-    return chaz_OS.name;
-}
-
-int
-chaz_OS_is_darwin(void) {
-    return memcmp(chaz_OS.name, "darwin", 6) == 0;
-}
-
-int
-chaz_OS_is_cygwin(void) {
-    return memcmp(chaz_OS.name, "cygwin", 6) == 0;
-}
-
-const char*
-chaz_OS_exe_ext(void) {
-    return chaz_OS.exe_ext;
-}
-
-const char*
-chaz_OS_shared_lib_ext(void) {
-    return chaz_OS.shared_lib_ext;
-}
-
-const char*
-chaz_OS_static_lib_ext(void) {
-    return chaz_OS.static_lib_ext;
+    free(output);
 }
 
 const char*

--- a/src/Charmonizer/Core/OperatingSystem.c
+++ b/src/Charmonizer/Core/OperatingSystem.c
@@ -63,13 +63,17 @@ chaz_OS_init(void) {
             printf("Detected cmd.exe shell\n");
         }
 
-        /* Try to see whether running commands via a hopefully POSIX
-         * compatible `sh` command works. */
+        /* Try to see whether running commands via the `sh` command works.
+         * Run the `find` command to check whether we're in a somewhat POSIX
+         * compatible environment. */
         free(output);
         chaz_OS.run_sh_via_cmd_exe = 1;
-        output = chaz_OS_run_and_capture("echo foo\\^bar", &output_len);
+        output = chaz_OS_run_and_capture("find . -prune", &output_len);
 
-        if (output_len >= 7 && memcmp(output, "foo^bar", 7) == 0) {
+        if (output_len >= 2
+            && output[0] == '.'
+            && isspace((unsigned char)output[1])
+           ) {
             if (chaz_Util_verbosity) {
                 printf("Detected POSIX shell via cmd.exe\n");
             }

--- a/src/Charmonizer/Core/OperatingSystem.c
+++ b/src/Charmonizer/Core/OperatingSystem.c
@@ -35,7 +35,11 @@ static struct {
     char dir_sep[2];
     char local_command_start[3];
     int  shell_type;
-} chaz_OS = { "", "", "", "", 0 };
+    int  run_sh_via_cmd_exe;
+} chaz_OS = { "", "", "", "", 0, 0 };
+
+static int
+chaz_OS_run_sh_via_cmd_exe(const char *command);
 
 void
 chaz_OS_init(void) {
@@ -58,11 +62,23 @@ chaz_OS_init(void) {
         if (chaz_Util_verbosity) {
             printf("Detected cmd.exe shell\n");
         }
-        chaz_OS.shell_type = CHAZ_OS_CMD_EXE;
-        strcpy(chaz_OS.dir_sep, "\\");
-        strcpy(chaz_OS.dev_null, "nul");
-        /* Empty string should work, too. */
-        strcpy(chaz_OS.local_command_start, ".\\");
+
+        /* Try to see whether running commands via a hopefully POSIX
+         * compatible `sh` command works. */
+        free(output);
+        chaz_OS.run_sh_via_cmd_exe = 1;
+        output = chaz_OS_run_and_capture("echo foo\\^bar", &output_len);
+
+        if (output_len >= 7 && memcmp(output, "foo^bar", 7) == 0) {
+            if (chaz_Util_verbosity) {
+                printf("Detected POSIX shell via cmd.exe\n");
+            }
+            chaz_OS.shell_type = CHAZ_OS_POSIX;
+        }
+        else {
+            chaz_OS.shell_type = CHAZ_OS_CMD_EXE;
+            chaz_OS.run_sh_via_cmd_exe = 0;
+        }
     }
     else if (output_len >= 7 && memcmp(output, "foo^bar", 7) == 0) {
         /* Escape character is backslash. */
@@ -70,6 +86,15 @@ chaz_OS_init(void) {
             printf("Detected POSIX shell\n");
         }
         chaz_OS.shell_type = CHAZ_OS_POSIX;
+    }
+
+    if (chaz_OS.shell_type == CHAZ_OS_CMD_EXE) {
+        strcpy(chaz_OS.dir_sep, "\\");
+        strcpy(chaz_OS.dev_null, "nul");
+        /* Empty string should work, too. */
+        strcpy(chaz_OS.local_command_start, ".\\");
+    }
+    else if (chaz_OS.shell_type == CHAZ_OS_POSIX) {
         strcpy(chaz_OS.dir_sep, "/");
         strcpy(chaz_OS.dev_null, "/dev/null");
         strcpy(chaz_OS.local_command_start, "./");
@@ -177,8 +202,91 @@ chaz_OS_run_redirected(const char *command, const char *path) {
     else {
         chaz_Util_die("Don't know the shell type");
     }
-    retval = system(quiet_command);
+    if (chaz_OS.run_sh_via_cmd_exe) {
+        retval = chaz_OS_run_sh_via_cmd_exe(quiet_command);
+    }
+    else {
+        retval = system(quiet_command);
+    }
     free(quiet_command);
+    return retval;
+}
+
+static int
+chaz_OS_run_sh_via_cmd_exe(const char *command) {
+    size_t i;
+    size_t size;
+    char *sh_command;
+    char *p;
+    int retval;
+
+    /* Compute size. */
+
+    size = sizeof("sh -c \"\"");
+
+    for (i = 0; command[i] != '\0'; i++) {
+        char c = command[i];
+
+        switch (c) {
+            case '"':
+            case '\\':
+                size += 2;
+                break;
+
+            case '%':
+            case '!':
+                size += 3;
+                break;
+
+            default:
+                size += 1;
+                break;
+        }
+    }
+
+    /* Build sh command. */
+
+    sh_command = (char*)malloc(size);
+    p = sh_command;
+    memcpy(p, "sh -c \"", 7);
+    p += 7;
+
+    /* Escape special characters. */
+
+    for (i = 0; command[i] != '\0'; i++) {
+        char c = command[i];
+
+        switch (c) {
+            case '"':
+            case '\\':
+                /* Escape double quote and backslash. */
+                *p++ = '\\';
+                *p++ = c;
+                break;
+
+            case '%':
+            case '!':
+                /* Break out of double quotes for percent sign and
+                 * exclamation mark. This prevents variable expansion. */
+                *p++ = '"';
+                *p++ = c;
+                *p++ = '"';
+                break;
+
+            default:
+                *p++ = c;
+                break;
+        }
+    }
+
+    /* Finish and run sh command. */
+
+    *p++ = '"';
+    *p++ = '\0';
+
+    retval = system(sh_command);
+
+    free(sh_command);
     return retval;
 }
 

--- a/src/Charmonizer/Core/OperatingSystem.c
+++ b/src/Charmonizer/Core/OperatingSystem.c
@@ -53,7 +53,7 @@ chaz_OS_init(void) {
 
     output = chaz_OS_run_and_capture("echo foo\\^bar", &output_len);
 
-    if (strncmp(output, "foo\\bar", 7) == 0) {
+    if (output_len >= 7 && memcmp(output, "foo\\bar", 7) == 0) {
         /* Escape character is caret. */
         if (chaz_Util_verbosity) {
             printf("Detected cmd.exe shell\n");
@@ -64,7 +64,7 @@ chaz_OS_init(void) {
         /* Empty string should work, too. */
         strcpy(chaz_OS.local_command_start, ".\\");
     }
-    else if (strncmp(output, "foo^bar", 7) == 0) {
+    else if (output_len >= 7 && memcmp(output, "foo^bar", 7) == 0) {
         /* Escape character is backslash. */
         if (chaz_Util_verbosity) {
             printf("Detected POSIX shell\n");

--- a/src/Charmonizer/Core/OperatingSystem.h
+++ b/src/Charmonizer/Core/OperatingSystem.h
@@ -68,32 +68,6 @@ chaz_OS_mkdir(const char *filepath);
 void
 chaz_OS_rmdir(const char *filepath);
 
-/* Return the operating system name.
- */
-const char*
-chaz_OS_name(void);
-
-int
-chaz_OS_is_darwin(void);
-
-int
-chaz_OS_is_cygwin(void);
-
-/* Return the extension for an executable on this system.
- */
-const char*
-chaz_OS_exe_ext(void);
-
-/* Return the extension for a shared object on this system.
- */
-const char*
-chaz_OS_shared_lib_ext(void);
-
-/* Return the extension for a static library on this system.
- */
-const char*
-chaz_OS_static_lib_ext(void);
-
 /* Return the equivalent of /dev/null on this system.
  */
 const char*

--- a/src/Charmonizer/Probe/DirManip.c
+++ b/src/Charmonizer/Probe/DirManip.c
@@ -119,7 +119,6 @@ chaz_DirManip_try_rmdir(void) {
 
 void
 chaz_DirManip_run(void) {
-    const char *dir_sep = chaz_OS_dir_sep();
     int has_dirent_h = chaz_HeadCheck_check_header("dirent.h");
     int has_direct_h = chaz_HeadCheck_check_header("direct.h");
     int has_dirent_d_namlen = false;
@@ -176,16 +175,13 @@ chaz_DirManip_run(void) {
         chaz_ConfWriter_add_def("MAKEDIR_MODE_IGNORED", "1");
     }
 
-    if (strcmp(dir_sep, "\\") == 0) {
+    if (chaz_CC_has_macro("_WIN32") && !chaz_CC_is_cygwin()) {
         chaz_ConfWriter_add_def("DIR_SEP", "\"\\\\\"");
         chaz_ConfWriter_add_def("DIR_SEP_CHAR", "'\\\\'");
     }
     else {
-        char scratch[5];
-        sprintf(scratch, "\"%s\"", dir_sep);
-        chaz_ConfWriter_add_def("DIR_SEP", scratch);
-        sprintf(scratch, "'%s'", dir_sep);
-        chaz_ConfWriter_add_def("DIR_SEP_CHAR", scratch);
+        chaz_ConfWriter_add_def("DIR_SEP", "\"/\"");
+        chaz_ConfWriter_add_def("DIR_SEP_CHAR", "'/'");
     }
 
     /* See whether remove works on directories. */


### PR DESCRIPTION
Detect shell by escape character. This should be more robust than
looking for /dev/null files.

Detect binary format by looking at the magic bytes of a compiled
executable.

Move information about binary format and file extensions to Compiler.
That's where it belongs if you think about cross-compiling.
